### PR TITLE
Domain objects, controller and service logic restructuring, Lambda execution fixes

### DIFF
--- a/src/lambda/index.js
+++ b/src/lambda/index.js
@@ -9,6 +9,8 @@ const awsServerlessExpress = require('aws-serverless-express'),
       api = express(),
       server = awsServerlessExpress.createServer(api);
 
+process.env.EXECUTION_CONTEXT = 'LAMBDA';
+
 api.use(bodyParser.json());
 api.use(bodyParser.urlencoded({ extended: true }));
 // Add middleware to pass Lambda payloads through standard express routing framework

--- a/src/lib/slack/blockController.js
+++ b/src/lib/slack/blockController.js
@@ -2,84 +2,63 @@
 
 const request = require('request-promise-native'),
       blockService = require('./blockService'),
+      errorResponseService = require('./errorResponseService'),
       smartappService = require('../smartthings/smartappService');
 
 const blockController = {
-    receive: async function(req, res) {
+    receive: async function(req) {
         const payload = JSON.parse(req.body.payload),
+              responseUrl = payload.response_url,
               action = payload.actions[0],
               command = action.action_id;
 
-        // Action IDs map to function names on this object. If a function is missing, that action is not supported
+        // Action IDs map to function names on the `commands` object below
+        // If a function is missing, that action is not supported
         if (this[command]) {
-            // If the action ID's function exists, execute it with the payload
-            await this[command](payload, action);
+            try {
+                await this[command](action, responseUrl);
+            } catch (err) {
+                console.error('ERROR ** Unexpected error receiving block command', err);
+                await errorResponseService.sendErrorResponse(responseUrl);
+            }
         } else {
             console.error('ERROR ** Unsupported command:', command);
-            await this.errorResponse(payload);
+            await errorResponseService.sendErrorResponse(responseUrl);
         }
-        res.end();
-    },
-
-    errorResponse: async function(payload) {
-        await request({
-	        method: 'POST',
-	        uri: payload.response_url,
-	        json: true,
-	        body: {'text': 'Uh oh, there was an error trying to handle your response. Please try again — sorry about that!'}
-        }).catch((err) => {
-            console.error('ERROR ** Error posting to Slack response URL in errorResponse', err);
-        });
     }
 };
 
 const commands = {
-    deviceList: async function(payload, action) {
+    listCommands: async function(action, responseUrl) {
         const deviceId = action.selected_option.value,
               deviceName = action.selected_option.text.text,
-              installedSmartAppId = action.block_id,
-              responseUrl = payload.response_url;
+              installedSmartAppId = action.block_id;
 
-        await blockService.sendDeviceCommands(deviceId, deviceName, installedSmartAppId, responseUrl)
-        .catch((err) => {
-            console.error(`Error sending device commands to Slack for device ${deviceId}`, err);
-        });
+        await blockService.sendDeviceCommands(deviceId, deviceName, installedSmartAppId, responseUrl);
     },
 
-    deviceOn: async function(payload, action) {
+    deviceOn: async function(action, responseUrl) {
         const deviceId = action.value,
-              installedSmartAppId = action.block_id,
-              responseUrl = payload.response_url;
+              installedSmartAppId = action.block_id;
 
-        await smartappService.executeDeviceOn(deviceId, installedSmartAppId, responseUrl)
-        .catch((err) => {
-            console.error(`Error executing device on command for device ${deviceId}`, err);
-        });
+        await smartappService.deviceOn(deviceId, installedSmartAppId, responseUrl);
     },
 
-    deviceOff: async function(payload, action) {
+    deviceOff: async function(action, responseUrl) {
         const deviceId = action.value,
-              installedSmartAppId = action.block_id,
-              responseUrl = payload.response_url;
+              installedSmartAppId = action.block_id;
 
-        await smartappService.executeDeviceOff(deviceId, installedSmartAppId, responseUrl)
-        .catch((err) => {
-            console.error(`Error executing device off command for device ${deviceId}`, err);
-        });
+        await smartappService.deviceOff(deviceId, installedSmartAppId, responseUrl);
     },
 
-    deviceSetColor: async function(payload, action) {
+    deviceSetColor: async function(action, responseUrl) {
         console.log('ACTION:', action);
 
         const deviceId = action.selected_option.value.split('.')[0],
               color = parseInt(action.selected_option.value.split('.')[1])/360*100, // Convert HSL Hue degree to percent
-              installedSmartAppId = action.block_id,
-              responseUrl = payload.response_url;
+              installedSmartAppId = action.block_id;
 
-        await smartappService.executeDeviceSetColor(deviceId, color, installedSmartAppId, responseUrl)
-        .catch((err) => {
-            console.error(`Error executing device setColor command for device ${deviceId}`, err);
-        });
+        await smartappService.deviceSetColor(deviceId, color, installedSmartAppId, responseUrl);
     }
 };
 

--- a/src/lib/slack/blockService.js
+++ b/src/lib/slack/blockService.js
@@ -1,113 +1,17 @@
 'use strict';
 
-const request = require('request-promise-native');
+const request = require('request-promise-native'),
+      DeviceCommand = require('./commands/DeviceCommand');
 
 const blockService = {
     sendDeviceCommands: async function(deviceId, deviceName, installedSmartAppId, responseUrl) {
+        const deviceCommand = Object.create(DeviceCommand).init(deviceId, deviceName, installedSmartAppId);
+
         await request({
 	        method: 'POST',
 	        uri: responseUrl,
 	        json: true,
-	        body: {
-                // `ephemeral` response type is only visible to the user running the slash command
-                // `in_channel` response type will be shown to the entire channel
-                "response_type": "ephemeral",
-                "text": `Select a command to send to ${deviceName}:`,
-                "blocks": [
-                    {
-                        "type": "section",
-                        "text": {
-                            "type": "mrkdwn",
-                            "text": `Select a command to send to ${deviceName}:`
-                        }
-                    },
-                    {
-                        "type": "actions",
-                        "block_id": installedSmartAppId,
-                        "elements": [
-                            {
-                                "type": "button",
-                                "action_id": "deviceOn",
-                                "text": {
-                                    "type": "plain_text",
-                                    "text": "Turn On",
-                                    "emoji": true
-                                },
-                                "value": deviceId
-                            },
-                            {
-                                "type": "button",
-                                "action_id": "deviceOff",
-                                "text": {
-                                    "type": "plain_text",
-                                    "text": "Turn Off",
-                                    "emoji": true
-                                },
-                                "value": deviceId
-                            },
-                            {
-                                "type": "static_select",
-                                "placeholder": {
-                                    "type": "plain_text",
-                                    "text": "Colors",
-                                    "emoji": true
-                                },
-                                "action_id": "deviceSetColor",
-                                "options": [
-                                    {
-                                        "text": {
-                                            "type": "plain_text",
-                                            "text": "Red",
-                                            "emoji": true
-                                        },
-                                        "value": `${deviceId}.0`
-                                    },
-                                    {
-                                        "text": {
-                                            "type": "plain_text",
-                                            "text": "Orange",
-                                            "emoji": true
-                                        },
-                                        "value": `${deviceId}.39`
-                                    },
-                                    {
-                                        "text": {
-                                            "type": "plain_text",
-                                            "text": "Green",
-                                            "emoji": true
-                                        },
-                                        "value": `${deviceId}.120`
-                                    },
-                                    {
-                                        "text": {
-                                            "type": "plain_text",
-                                            "text": "Cyan",
-                                            "emoji": true
-                                        },
-                                        "value": `${deviceId}.180`
-                                    },
-                                    {
-                                        "text": {
-                                            "type": "plain_text",
-                                            "text": "Blue",
-                                            "emoji": true
-                                        },
-                                        "value": `${deviceId}.240`
-                                    },
-                                    {
-                                        "text": {
-                                            "type": "plain_text",
-                                            "text": "Purple",
-                                            "emoji": true
-                                        },
-                                        "value": `${deviceId}.280`
-                                    }
-                                ]
-                            }
-                        ]
-                    }
-                ]
-            }
+	        body: deviceCommand.commandsBlock
         }).catch((err) => {
             console.error('Error posting to Slack response URL in deviceList', err);
         });

--- a/src/lib/slack/commandController.js
+++ b/src/lib/slack/commandController.js
@@ -1,67 +1,31 @@
 'use strict';
 
-const commandService = require('./commandService');
+const commandService = require('./commandService'),
+      errorResponseService = require('./errorResponseService');
 
 const commandController = {
-    thingsbot: async function(req, res) {
-        const installedSmartAppId = req.query.installedSmartAppId;
-        const devices = await commandService.getDevices(installedSmartAppId);
-        if (!devices || !Array.isArray(devices)) {
-            console.error('ERROR ** Failed to pull valid device list in commandController:', devices)
-            res.send({
-                "response_type": "ephemeral",
-                "text": "Uh oh, there was a problem pulling your device list. Please try again."
-            });
-            return;
-        } else if (devices.length == 0) {
-            res.send({
-                "response_type": "ephemeral",
-                "text": "Oops, looks like you don't have any devices on your SmartThings account! Please add a device and then try again."
-            });
-            return;
+    routeCommand: async function(req, command) {
+        if (this[command]) {
+            try {
+                await this[command](req);
+            } catch (err) {
+                console.error('ERROR ** Unexpected error routing slash command', err);
+                await errorResponseService.sendErrorResponse(req.body.response_url);
+            }
+        } else {
+            console.error('ERROR ** Unsupported slash command:', command);
+            await errorResponseService.sendErrorResponse(req.body.response_url);
         }
-
-        res.send({
-            // `ephemeral` response type is only visible to the user running the slash command
-            // `in_channel` response type will be shown to the entire channel
-            "response_type": "ephemeral",
-            "text": "Select a device to send a command to:",
-            "blocks": [
-                {
-                    "type": "section",
-                    "text": {
-                        "type": "mrkdwn",
-                        "text": "Select a device to send a command to:"
-                    }
-                },
-                {
-                    "type": "actions",
-                    "block_id": installedSmartAppId,
-                    "elements": [
-                        {
-                            "type": "static_select",
-                            "placeholder": {
-                                "type": "plain_text",
-                                "text": "Devices",
-                                "emoji": true
-                            },
-                            "action_id": "deviceList",
-                            "options": devices.map((device) => {
-                                return {
-                                    "text": {
-                                        "type": "plain_text",
-                                        "text": device.name,
-                                        "emoji": true
-                                    },
-                                    "value": device.deviceId
-                                };
-                            })
-                        }
-                    ]
-                }
-            ]
-        });
     }
-};
+}
 
+const commands = {
+    thingsbot: async function(req) {
+        const installedSmartAppId = req.query.installedSmartAppId;
+
+        return await commandService.thingsbotCommand(installedSmartAppId, req.body);
+    }
+}
+
+Object.setPrototypeOf(commandController, commands);
 module.exports = commandController;

--- a/src/lib/slack/commandService.js
+++ b/src/lib/slack/commandService.js
@@ -1,21 +1,16 @@
 'use strict';
 
-const smartappService = require('../smartthings/smartappService');
+const ThingsBotCommand = require('./commands/ThingsBotCommand');
 
 const commandService = {
-    getDevices: async function(installedSmartAppId) {
-        const [ contextError, smartappContext ] = await smartappService.getSmartAppContext(installedSmartAppId);
-        if (contextError) { return; }
+    thingsbotCommand: async function(installedSmartAppId, payload) {
+        const command = Object.create(ThingsBotCommand).init(installedSmartAppId, payload);
 
-        var deviceListError;
-        const deviceList = await smartappContext.api.devices.listAll();
-        .catch((err) => {
-            console.error(`Error listing devices for InstalledSmartApp ${installedSmartAppId}`, err);
-            deviceListError = err;
-        });
-        if (deviceListError) { return; }
-        
-        return deviceList.items;
+        if (!command) {
+            return Promise.reject('Failed to initialize new ThingsBotCommand Object');
+        }
+
+        await command.sendResponse(await command.deviceCommandsBlock)
     }
 };
 

--- a/src/lib/slack/commands/DeviceCommand.js
+++ b/src/lib/slack/commands/DeviceCommand.js
@@ -1,0 +1,114 @@
+'use strict';
+
+const DeviceCommand = {
+    init(deviceId, deviceName, installedSmartAppId) {
+        this.deviceId = deviceId;
+        this.deviceName = deviceName;
+        this.installedSmartAppId = installedSmartAppId;
+
+        return this;
+    },
+
+    get commandsBlock() {
+        return {
+            "response_type": "ephemeral",
+            "text": `Select a command to send to ${this.deviceName}:`,
+            "blocks": [
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": `Select a command to send to ${this.deviceName}:`
+                    }
+                },
+                {
+                    "type": "actions",
+                    "block_id": this.installedSmartAppId,
+                    "elements": [
+                        {
+                            "type": "button",
+                            "action_id": "deviceOn",
+                            "text": {
+                                "type": "plain_text",
+                                "text": "Turn On",
+                                "emoji": true
+                            },
+                            "value": this.deviceId
+                        },
+                        {
+                            "type": "button",
+                            "action_id": "deviceOff",
+                            "text": {
+                                "type": "plain_text",
+                                "text": "Turn Off",
+                                "emoji": true
+                            },
+                            "value": this.deviceId
+                        },
+                        {
+                            "type": "static_select",
+                            "placeholder": {
+                                "type": "plain_text",
+                                "text": "Colors",
+                                "emoji": true
+                            },
+                            "action_id": "deviceSetColor",
+                            "options": [
+                                {
+                                    "text": {
+                                        "type": "plain_text",
+                                        "text": "Red",
+                                        "emoji": true
+                                    },
+                                    "value": `${this.deviceId}.0`
+                                },
+                                {
+                                    "text": {
+                                        "type": "plain_text",
+                                        "text": "Orange",
+                                        "emoji": true
+                                    },
+                                    "value": `${this.deviceId}.39`
+                                },
+                                {
+                                    "text": {
+                                        "type": "plain_text",
+                                        "text": "Green",
+                                        "emoji": true
+                                    },
+                                    "value": `${this.deviceId}.120`
+                                },
+                                {
+                                    "text": {
+                                        "type": "plain_text",
+                                        "text": "Cyan",
+                                        "emoji": true
+                                    },
+                                    "value": `${this.deviceId}.180`
+                                },
+                                {
+                                    "text": {
+                                        "type": "plain_text",
+                                        "text": "Blue",
+                                        "emoji": true
+                                    },
+                                    "value": `${this.deviceId}.240`
+                                },
+                                {
+                                    "text": {
+                                        "type": "plain_text",
+                                        "text": "Purple",
+                                        "emoji": true
+                                    },
+                                    "value": `${this.deviceId}.280`
+                                }
+                            ]
+                        }
+                    ]
+                }
+            ]
+        }
+    }
+}
+
+module.exports = DeviceCommand;

--- a/src/lib/slack/commands/SlashCommand.js
+++ b/src/lib/slack/commands/SlashCommand.js
@@ -1,0 +1,51 @@
+'use strict';
+
+const request = require('request-promise-native');
+
+const SlashCommand = {
+    initSlashCommand(body = {}) {
+        const validated = requireParams(body, ['response_url', 'channel_id', 'user_id']);
+        if (!validated) { return; }
+
+        // Required params
+        this.responseUrl = body.response_url;
+        this.channelId = body.channel_id;
+        this.userId = body.user_id;
+
+        // Optional params
+        this.text = body.text;
+        this.triggerId = body.trigger_id;
+        this.command = body.command;
+        this.userName = body.user_name;
+        this.teamId = body.team_id;
+        this.teamDomain = body.team_domain;
+        this.enterpriseId = body.enterprise_id;
+        this.enterpriseName = body.enterprise_name;
+
+        return this;
+    },
+
+    sendResponse: async function(block) {
+        await request({
+	        method: 'POST',
+	        uri: this.responseUrl,
+	        json: true,
+	        body: block
+        }).catch((err) => {
+            console.error('ERROR ** Error posting to Slack response URL for slash command', err);
+        });
+    }
+}
+
+function requireParams(body, params) {
+    var validated = true;
+    for (var param of params) {
+        if (!body[param]) {
+            console.error(`ERROR ** Unable to init SlashCommand, no ${param} param found in body:`, body);
+            validated = false;
+        }
+    }
+    return validated;
+}
+
+module.exports = SlashCommand;

--- a/src/lib/slack/commands/ThingsBotCommand.js
+++ b/src/lib/slack/commands/ThingsBotCommand.js
@@ -1,0 +1,87 @@
+'use strict';
+
+const SlashCommand = require('./SlashCommand'),
+      smartappService = require('../../smartthings/smartappService');
+
+const ThingsBotCommand = {
+    init(installedSmartAppId, body = {}) {
+        if (!installedSmartAppId) {
+            console.error(`ERROR ** Unable to init ThingsBotCommand, no installedSmartAppId passed in`);
+            return;
+        }
+        this.installedSmartAppId = installedSmartAppId;
+
+        return this.initSlashCommand(body);
+    },
+
+    get deviceCommandsBlock() {
+        return (async() => {
+            const deviceList = await getDeviceList(this.installedSmartAppId);
+
+            if (!deviceList) {
+                console.error('ERROR ** Failed to pull valid device list in deviceCommandsBlock getter')
+                return {
+                    "response_type": "ephemeral",
+                    "text": "Uh oh, there was a problem pulling your device list. Please try again."
+                };
+            } else if (deviceList.length == 0) {
+                return {
+                    "response_type": "ephemeral",
+                    "text": "Oops, looks like you don't have any devices on your SmartThings account! Please add a device and then try again."
+                };
+            }
+            
+            return {
+                "response_type": "ephemeral",
+                "text": "Select a device to send a command to:",
+                "blocks": [
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": "Select a device to send a command to:"
+                        }
+                    },
+                    {
+                        "type": "actions",
+                        "block_id": this.installedSmartAppId,
+                        "elements": [
+                            {
+                                "type": "static_select",
+                                "placeholder": {
+                                    "type": "plain_text",
+                                    "text": "Devices",
+                                    "emoji": true
+                                },
+                                "action_id": "listCommands",
+                                "options": (deviceList).map((device) => {
+                                    return {
+                                        "text": {
+                                            "type": "plain_text",
+                                            "text": device.name,
+                                            "emoji": true
+                                        },
+                                        "value": device.deviceId
+                                    };
+                                })
+                            }
+                        ]
+                    }
+                ]
+            };
+        })();
+    }
+}
+
+async function getDeviceList(installedSmartAppId) {
+    const [ contextError, smartappContext ] = await smartappService.getSmartAppContext(installedSmartAppId);
+    if (contextError) { return; }
+
+    const [ deviceListError, deviceList ] = await smartappService.getDeviceList(smartappContext);
+    if (deviceListError) { return; }
+    
+    return deviceList ? deviceList.items : [];
+}
+
+Object.setPrototypeOf(ThingsBotCommand, SlashCommand);
+module.exports = ThingsBotCommand;

--- a/src/lib/slack/errorResponseService.js
+++ b/src/lib/slack/errorResponseService.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const request = require('request-promise-native');
+
+const errorResponseService = {
+    sendErrorResponse: async function(responseUrl) {
+        if (!responseUrl) {
+            console.error('ERROR ** No response URL passed to errorResponseService, unable to deliver error message to user');
+            return;
+        }
+
+        await request({
+	        method: 'POST',
+	        uri: responseUrl,
+	        json: true,
+	        body: {
+                text: 'Uh oh, there was an unexpected error while attempting to execute your command. Please try again.'
+            }
+        }).catch((err) => {
+            console.error('ERROR ** Error posting to Slack response URL', err);
+        });
+    }
+}
+
+module.exports = errorResponseService;

--- a/src/lib/slack/index.js
+++ b/src/lib/slack/index.js
@@ -4,13 +4,32 @@ const router = require('express').Router(),
       commandController = require('./commandController'),
       blockController = require('./blockController');
 
+// Dumb hack to deal with Lambda's premature execution termination
+async function route(res, promise) {
+    if (process.env.EXECUTION_CONTEXT != 'LAMBDA') {
+        res.status(200).send();
+    }
+
+    await promise
+    .catch((err) => {
+        console.error('ERROR ** Caught unhandled error in API execution:', err);
+    });
+
+    if (process.env.EXECUTION_CONTEXT == 'LAMBDA') {
+        res.status(200).send();
+    }
+}
+
 router.post('/cmd/thingsbot', (req, res) => {
-    commandController.thingsbot(req, res);
+    route(res, 
+        commandController.routeCommand(req, 'thingsbot')
+    );
 });
 
-router.post('/receive', async (req, res) => {
-    res.write('');
-    await blockController.receive(req, res);
+router.post('/receive', (req, res) => {
+    route(res, 
+        blockController.receive(req)
+    );
 });
 
 module.exports = router;


### PR DESCRIPTION
- Add domain objects for commands
- Restructure controllers and services to have better separation of concerns and to use the domain objects
- Lambda handler file sets an execution context variable so we know when we're running on Lambda
    - When running on Lambda, responses don't send 200 statuses until we've completed our execution. This may result in timeouts sometimes, but in my experimenting the timeouts are fairly rare, and never happen when the Lambda is warm
    - When not running on Lambda, statuses are sent immediately (as they should be, but Lambda isn't going to play nicely with that idea unless we run multiple lambdas and chain them together)

/cc @gausnes 